### PR TITLE
Proper Default to Avoid Empty Checkworthy Set

### DIFF
--- a/runs/score_all.sh
+++ b/runs/score_all.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 
-export OUTPUT_PATH=data/outputs/generation_opt.json
+export OUTPUT_PATH=data/outputs/generation_opt_corner_cases.json
 export CACHE_PATH=.cache/.mistral-7b-cache.db
 export SCORE_DIR=data/scores/local_models/
 
-export SCORE_PATH=${SCORE_DIR}mistral-soft-deberta-base-parallel.json
+export SCORE_PATH=${SCORE_DIR}mistral-soft-deberta-base-parallel-corner.json
 conda run -p .env --no-capture-output \
     python scripts/run_task.py configs/dedupsoft_configs.yaml \
     --cache-path $CACHE_PATH

--- a/src/retriever/retriever.py
+++ b/src/retriever/retriever.py
@@ -346,11 +346,13 @@ class Retriever(object):
         cache_keys_need_to_check = []
         queries_need_to_check = []
         passages_need_to_check = []
+        
+        cnc_set = set()
 
         for topic, query, key in zip(topics, queries, cache_keys):
             if key in self.cache:
                 result_dict[key] = self.cache[key]
-            else:
+            elif key not in cnc_set:
                 passages = self.db.get_text_from_title(topic)
                 # if len(passages) <= k:
                 #     result_dict[key] = passages
@@ -359,6 +361,7 @@ class Retriever(object):
                 queries_need_to_check.append(query)
                 cache_keys_need_to_check.append(key)
                 passages_need_to_check.append(passages)
+                cnc_set.add(key)
                 
         if self.retrieval_type != 'bm25':
             filtered_passage_results = self.get_gtr_passages_batched(

--- a/src/scorer/decompose_scorer.py
+++ b/src/scorer/decompose_scorer.py
@@ -89,10 +89,8 @@ class DecomposeScorer(Scorer):
         # print(decomposed_instance_tuples)
         
         # grouped parsed scores by index
-        grouped_parsed_scores = {}
+        grouped_parsed_scores = {idx: [] for idx in range(len(instances))}
         for (idx, di), score_dict in zip(decomposed_instance_tuples, raw_scores):
-            if idx not in grouped_parsed_scores:
-                grouped_parsed_scores[idx] = []
             grouped_parsed_scores[idx].append({**score_dict, **asdict(di)})
             
         for idx, score_dicts in grouped_parsed_scores.items():


### PR DESCRIPTION
Add proper scorer default to deal with the empty check-worthy set (We fall back to the agagregation score of an empty set, in the case of `FActScoreAggregator` the current behavior is to return 0.0, as in the original paper).